### PR TITLE
Use "%kernel.project_dir%" (application path) in the documentation 

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Use `bin/console debug:config ignition` to see configuration options.
 `config/packages/ignition.yaml`:
 ```
 ignition:
-    application_path: ''
+    application_path: '%kernel.project_dir%'
     dark_mode: false
     should_display_exceptions: '%kernel.debug%'
     # if you want AI solutions to your app's errors


### PR DESCRIPTION
Hello, 

I propose to use [%kernel.project_dir%](https://symfony.com/doc/current/reference/configuration/kernel.html#kernel-project-dir) in the documentation to set the path correctly. 
```yml
ignition:
  application_path: '%kernel.project_dir%'
```

It may be appropriate to set it by default, if not indicated in the configuration. Let me know, I could do a PR for it or amend the PR. 