### PR TITLE
PHP and Symfony version support updates

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -1,6 +1,6 @@
 name: Tests
 
-on: [push, pull_request]
+on: pull_request
 
 jobs:
   test:
@@ -8,11 +8,26 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest]
-        php: [8.1, 8.0]
-        stability: [prefer-lowest, prefer-stable]
+        os:
+          - ubuntu-latest
+          - windows-latest
+        php:
+          - '8.1'
+          - '8.2'
+          - '8.3'
+        symfony:
+          - '5.4.*'
+          - '6.3.*'
+          - '6.4.*'
+          - '7.0.*'
+        stability:
+          - prefer-lowest
+          - prefer-stable
+        exclude:
+          - { symfony: '7.0.*', php: '8.1' }
+          - { symfony: '7.0.*', php: '8.2' }
 
-    name: P${{ matrix.php }} - ${{ matrix.stability }} - ${{ matrix.os }}
+    name: PHP ${{ matrix.php }} / Symfony ${{ matrix.symfony }} - ${{ matrix.stability }} - ${{ matrix.os }}
 
     steps:
       - name: Checkout code
@@ -29,6 +44,9 @@ jobs:
         run: |
           echo "::add-matcher::${{ runner.tool_cache }}/php.json"
           echo "::add-matcher::${{ runner.tool_cache }}/phpunit.json"
+
+      - name: Write Symfony requirement
+        run: echo "${{ matrix.symfony }}" > ${{ github.workspace }}/symfony-version.txt
 
       - name: Install dependencies
         run: composer update --${{ matrix.stability }} --prefer-dist --no-interaction

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,4 @@
+FROM php:8.2
+WORKDIR /var/task
+RUN apt-get update -y && apt-get install -y git zip unzip
+COPY --from=composer:2 /usr/bin/composer /usr/local/bin/composer

--- a/composer.json
+++ b/composer.json
@@ -21,9 +21,9 @@
         }
     ],
     "require": {
-        "php": "^8.0",
+        "php": "^8.1",
         "spatie/ignition": "^1.0",
-        "symfony/dependency-injection": "^5.4 || ^6.0 || ^7.0",
+        "symfony/dependency-injection": "^5.4 || ^6.3 || ^7.0",
         "symfony/config": "^5.4 || ^6.0 || ^7.0",
         "symfony/http-kernel": "^5.4 || ^6.0 || ^7.0",
         "symfony/event-dispatcher": "^5.4 || ^6.0 || ^7.0",
@@ -55,6 +55,6 @@
             "pestphp/pest-plugin": true
         }
     },
-    "minimum-stability": "dev",
+    "minimum-stability": "stable",
     "prefer-stable": true
 }

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,9 @@
+version: '3'
+services:
+  ignition-bundle-test-environment:
+    container_name: ignition-bundle
+    build: .
+    image: php:8.2
+    tty: true
+    volumes:
+      - .:/var/task

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -7,7 +7,7 @@ use Symfony\Component\Config\Definition\ConfigurationInterface;
 
 class Configuration implements ConfigurationInterface
 {
-    public function getConfigTreeBuilder()
+    public function getConfigTreeBuilder(): TreeBuilder
     {
         $treeBuilder = new TreeBuilder('ignition');
         $rootNode = $treeBuilder->getRootNode();

--- a/tests/Functional/AppTemplate/composer.json
+++ b/tests/Functional/AppTemplate/composer.json
@@ -12,7 +12,7 @@
         }
     ],
     "require": {
-        "php": ">=7.2.5",
+        "php": ">=8.1.0",
         "ext-ctype": "*",
         "ext-iconv": "*",
         "spatie/symfony-ignition-bundle": "*",

--- a/tests/Functional/FunctionalTest.php
+++ b/tests/Functional/FunctionalTest.php
@@ -22,13 +22,12 @@ abstract class FunctionalTest extends TestCase
      */
     public function versionProvider()
     {
-        return [
-            'Symfony 5.4' => ['5.4.*'],
-            'Symfony 6.0' => ['6.0.*'],
-        ];
+        $symfonyVersion = trim(file_get_contents(__DIR__ . '/../../symfony-version.txt'));
+
+        return $symfonyVersion;
     }
 
-    protected function installSymfony(string $symfonyRequirement = '6.0.*'): void
+    protected function installSymfony(string $symfonyVersion): void
     {
         // Create a fresh directory for the Symfony app using the template
         $filesystem = new Filesystem();
@@ -36,7 +35,7 @@ abstract class FunctionalTest extends TestCase
         // Windows was having trouble with Filesystem::remove, so rename instead
         // $filesystem->remove(self::APP_DIRECTORY);
         if (file_exists(self::APP_DIRECTORY)) {
-            $filesystem->rename(self::APP_DIRECTORY, self::APP_DIRECTORY . '~');
+            $filesystem->rename(self::APP_DIRECTORY, self::APP_DIRECTORY . '~', overwrite: true);
         }
         $filesystem->mirror(self::APP_TEMPLATE, self::APP_DIRECTORY);
 
@@ -51,7 +50,7 @@ abstract class FunctionalTest extends TestCase
                 '--optimize-autoloader',
             ],
             self::APP_DIRECTORY,
-            ['SYMFONY_REQUIRE' => $symfonyRequirement]
+            ['SYMFONY_REQUIRE' => $symfonyVersion]
         );
 
         $composerInstall->mustRun();

--- a/tests/Functional/InstallWithSymfonyTest.php
+++ b/tests/Functional/InstallWithSymfonyTest.php
@@ -5,18 +5,18 @@ namespace Spatie\SymfonyIgnitionBundle\Tests\Functional;
 use Symfony\Component\DomCrawler\Crawler;
 use Symfony\Component\Process\Process;
 
-class InstallWithSymfony extends FunctionalTest
+class InstallWithSymfonyTest extends FunctionalTest
 {
     /**
      * Install a Symfony application. Verify its version with bin/console, then
-     * fake a HTTP request to the front controller. Assert the response is an
+     * fake an HTTP request to the front controller. Assert the response is an
      * Ignition error page thrown in a Symfony controller.
      *
      * @dataProvider versionProvider
      */
-    public function testSymfonyWorks(string $symfonyRequirement): void
+    public function testSymfonyWorks(string $symfonyVersion): void
     {
-        $this->installSymfony($symfonyRequirement);
+        $this->installSymfony($symfonyVersion);
 
         // Assert the expected version of Symfony was installed
         $getSymfonyVersion = new Process([
@@ -29,7 +29,7 @@ class InstallWithSymfony extends FunctionalTest
         $this->assertCommandIsSuccessful($getSymfonyVersion);
 
         $versionOutput = $getSymfonyVersion->getOutput();
-        $majorDotMinorSymfonyRequirement = implode('.', explode('.', $symfonyRequirement, -1));
+        $majorDotMinorSymfonyRequirement = implode('.', explode('.', ltrim($symfonyVersion, '^>='), -1));
         $expectedOutput = sprintf('Symfony %s', $majorDotMinorSymfonyRequirement);
         $this->assertStringContainsString($expectedOutput, $versionOutput);
 


### PR DESCRIPTION
Drop support for:

- PHP 8.0
- Symfony 6.0
- Symfony 6.2

Add support for:

- PHP 8.2
- PHP 8.3
- Symfony 7.0