### PR TITLE
Fix configuration example at README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,13 +47,14 @@ Enable the bundle in `config/bundles.php`:
 Use `bin/console debug:config ignition` to see configuration options.
 
 `config/packages/ignition.yaml`:
-```
-ignition:
-    application_path: '%kernel.project_dir%'
-    dark_mode: false
-    should_display_exceptions: '%kernel.debug%'
-    # if you want AI solutions to your app's errors
-    openai_key: 'key-here'
+```yaml
+when@dev:
+    ignition:
+        application_path: '%kernel.project_dir%'
+        dark_mode: false
+        should_display_exception: '%kernel.debug%'
+        # if you want AI solutions to your app's errors
+        openai_key: 'key-here'
 ```
 
 ## Usage


### PR DESCRIPTION
### 1.
 Since bundle is enabled only at `dev` in installation example, configuration example should be wrapped with [`when@dev`](https://symfony.com/blog/new-in-symfony-5-3-configure-multiple-environments-in-a-single-file)

### 2.

```patch
--- should_display_exceptions
+++ should_display_exception
```