### PR TITLE
Add openai_key as an option to the Symfony config

### DIFF
--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -25,6 +25,10 @@ class Configuration implements ConfigurationInterface
                     ->defaultValue('%kernel.debug%')
                     ->info('Avoid rendering Ignition, for example in production environments.')
                     ->end()
+                ->scalarNode('openai_key')
+                    ->defaultValue('')
+                    ->info('if you want AI solutions to your app\'s errors.')
+                    ->end()
             ->end();
 
         return $treeBuilder;


### PR DESCRIPTION
This is a fix for #30.  It adds openai_key as a valid option for the symfony configuration.